### PR TITLE
Include period (.) in dist-info and package name

### DIFF
--- a/variant_repack/commands/build.py
+++ b/variant_repack/commands/build.py
@@ -53,7 +53,7 @@ def sanitize_wheel_filename(filename: str) -> str:
         raise ValueError(f"Invalid wheel filename: {filename}")
 
     # Remove +<build_tag> from the version part (index 1)
-    parts[1] = re.sub(r"\+[a-zA-Z0-9_]+", "", parts[1])
+    parts[1] = re.sub(r"\+[a-zA-Z0-9_\.]+", "", parts[1])
 
     return "-".join(parts)
 
@@ -274,10 +274,10 @@ def make_variant(
 
         # Remove version suffix patterns like +cu126, +cpu, etc. from dist-info
         # directory name
-        new_dir_name = re.sub(r"\+[a-zA-Z0-9_]+", "", distinfo_dir.name)
+        new_dir_name = re.sub(r"\+[a-zA-Z0-9_\.]+\.", ".", distinfo_dir.name)
         if new_dir_name != distinfo_dir.name:
             new_distinfo_dir = distinfo_dir.parent / new_dir_name
-            distinfo_dir = distinfo_dir.rename(new_distinfo_dir)
+            distinfo_dir.rename(new_distinfo_dir)
             logger.debug(
                 f"Renamed dist-info directory from {distinfo_dir.name} to "
                 f"{new_dir_name}"


### PR DESCRIPTION
Correctly renames dist-info directory and package name in cases where the local identifier has a "." in it eg. https://download.pytorch.org/whl/rocm6.2.4/torchvision/ : `torchvision-0.21.0+rocm6.2.4-cp313-cp313-linux_x86_64.whl`

### Without changes in this PR:
```
variant_repack.commands.build - DEBUG - Renamed dist-info directory from torchvision-0.20.0.3.0.dist-info to torchvision-0.20.0.3.0.dist-info
Repacking wheel as /tmp/tmpsckzw44w/torchvision-0.20.0.3.0-cp310-cp310-linux_x86_64.whl...OK
```

### With changes in this PR:
```
variant_repack.commands.build - DEBUG - Renamed dist-info directory from torchvision-0.20.0+rocm6.3.0.dist-info to torchvision-0.20.0.dist-info
...
Repacking wheel as /tmp/tmpvl4jr1ia/torchvision-0.20.0-cp310-cp310-linux_x86_64.whl...OK
```

