### PR TITLE
Add torch-2.8 variant config for Intel GPUs (XPU backend)

### DIFF
--- a/configs/torch-2.8/torch-2.8.0-variants.json
+++ b/configs/torch-2.8/torch-2.8.0-variants.json
@@ -2,7 +2,8 @@
     "$schema": "https://variants-schema.wheelnext.dev/",
     "default-priorities": {
         "namespace": [
-            "nvidia"
+            "nvidia",
+            "intel"
         ]
     },
     "providers": {
@@ -11,6 +12,13 @@
             "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
             "requires": [
                 "nvidia-variant-provider>=0.0.1,<1.0.0"
+            ]
+        },
+        "intel": {
+            "enable-if": "platform_system == 'Linux'",
+            "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
+            "requires": [
+                "intel-variant-provider"
             ]
         }
     },
@@ -62,6 +70,18 @@
                     "80_real",
                     "86_real",
                     "90_real"
+                ]
+            }
+        },
+        "xpu": {
+            "intel": {
+                "device_ip": [
+                    "12.55.8",
+                    "12.60.7",
+                    "12.71.4",
+                    "12.74.4",
+                    "20.1.0",
+                    "20.4.4"
                 ]
             }
         }

--- a/configs/torch-2.8/torch_pyproject.toml
+++ b/configs/torch-2.8/torch_pyproject.toml
@@ -1,8 +1,13 @@
 # https://github.com/pytorch/pytorch/blob/b46ca66793573f00f5bb7f8664ae72b4a5f38a2a/pyproject.toml
 [variant.default-priorities]
-namespace = ["nvidia"]
+namespace = ["nvidia", "intel"]
 
 [variant.providers.nvidia]
 requires = ["nvidia-variant-provider>=0.0.1,<1.0.0"]
 plugin-api = "nvidia_variant_provider.plugin:NvidiaVariantPlugin"
 enable-if = "platform_system == 'Linux' or platform_system == 'Windows'"
+
+[variant.providers.intel]
+requires = ["intel-variant-provider"]
+enable-if = "platform_system == 'Linux'"
+plugin-api = "intel_variant_provider.plugin:IntelVariantPlugin"

--- a/configs/torch-2.8/torch_variant_config.toml
+++ b/configs/torch-2.8/torch_variant_config.toml
@@ -115,6 +115,17 @@ properties = [
   { namespace = "nvidia", feature = "sm_arch", value = "120_virtual" },
 ]
 
+[variant_configs.intel]
+variant_label = "xpu"  # [a-z0-9_]{1,8}
+properties = [
+  { namespace = "intel", feature = "device_ip", value = "20.4.4" },   # lnl-m
+  { namespace = "intel", feature = "device_ip", value = "20.1.0" },   # bmg
+  { namespace = "intel", feature = "device_ip", value = "12.74.4" },  # arl-h
+  { namespace = "intel", feature = "device_ip", value = "12.71.4" },  # mtl-h
+  { namespace = "intel", feature = "device_ip", value = "12.60.7" },  # pvc
+  { namespace = "intel", feature = "device_ip", value = "12.55.8" },  # dg2
+]
+
 [variant_configs.cpu]
 # variant_label = None  # FORBIDDEN - No Alias -> NULL VARIANT: `00000000`
 properties = []

--- a/configs/torch-2.8/torch_variant_config.toml
+++ b/configs/torch-2.8/torch_variant_config.toml
@@ -3,6 +3,7 @@
 normalize_package_name = false
 normalize_version = true
 deps_remove_list = [
+  # CUDA
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-cuda-runtime-cu12",
   "nvidia-cuda-cupti-cu12",
@@ -17,7 +18,28 @@ deps_remove_list = [
   "nvidia-nvtx-cu12",
   "nvidia-nvjitlink-cu12",
   "nvidia-cufile-cu12",
-  "triton"
+  "triton",
+  # XPU
+  'dpcpp-cpp-rt',
+  'impi-rt',
+  'intel-cmplr-lib-rt',
+  'intel-cmplr-lib-ur',
+  'intel-cmplr-lic-rt',
+  'intel-opencl-rt',
+  'intel-openmp',
+  'intel-pti',
+  'intel-sycl-rt',
+  'mkl',
+  'oneccl-devel',
+  'oneccl',
+  'onemkl-sycl-blas',
+  'onemkl-sycl-dft',
+  'onemkl-sycl-lapack',
+  'onemkl-sycl-rng',
+  'onemkl-sycl-sparse',
+  'pytorch-triton-xpu',
+  'tbb',
+  'umf',
 ]
 deps_add_list    = [
     # Common to all CUDA Variants
@@ -64,6 +86,28 @@ deps_add_list    = [
     'nvidia-nvtx==12.9.79; platform_system == "Linux" and platform_machine == "x86_64" and "nvidia :: cuda_version_lower_bound :: 12.0" not in variant_properties and "nvidia :: cuda_version_lower_bound :: 12.8" not in variant_properties and "nvidia :: cuda_version_lower_bound :: 12.9" in variant_properties',
     'nvidia-nvjitlink==12.9.86; platform_system == "Linux" and platform_machine == "x86_64" and "nvidia :: cuda_version_lower_bound :: 12.0" not in variant_properties and "nvidia :: cuda_version_lower_bound :: 12.8" not in variant_properties and "nvidia :: cuda_version_lower_bound :: 12.9" in variant_properties',
     'nvidia-cufile==1.14.1.1; platform_system == "Linux" and platform_machine == "x86_64" and "nvidia :: cuda_version_lower_bound :: 12.0" not in variant_properties and "nvidia :: cuda_version_lower_bound :: 12.8" not in variant_properties and "nvidia :: cuda_version_lower_bound :: 12.9" in variant_properties',
+
+    # XPU
+    'dpcpp-cpp-rt==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'impi-rt==2021.15.0; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
+    'intel-cmplr-lib-rt==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-cmplr-lib-ur==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-cmplr-lic-rt==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-opencl-rt==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-openmp==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-pti==0.12.3; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-sycl-rt==2025.1.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'mkl==2025.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'oneccl-devel==2021.15.2; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
+    'oneccl==2021.15.2; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
+    'onemkl-sycl-blas==2025.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-dft==2025.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-lapack==2025.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-rng==2025.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-sparse==2025.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'pytorch-triton-xpu==3.4.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'tbb==2022.1.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'umf==0.10.0; platform_system == "Linux" and "intel" in variant_namespaces',
 ]
 
 [metadata_configs.torchvision]

--- a/configs/torch-2.8/torchvision-0.23.0-variants.json
+++ b/configs/torch-2.8/torchvision-0.23.0-variants.json
@@ -2,7 +2,8 @@
     "$schema": "https://variants-schema.wheelnext.dev/",
     "default-priorities": {
         "namespace": [
-            "nvidia"
+            "nvidia",
+            "intel"
         ]
     },
     "providers": {
@@ -11,6 +12,13 @@
             "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
             "requires": [
                 "nvidia-variant-provider>=0.0.1,<1.0.0"
+            ]
+        },
+        "intel": {
+            "enable-if": "platform_system == 'Linux'",
+            "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
+            "requires": [
+                "intel-variant-provider"
             ]
         }
     },
@@ -62,6 +70,18 @@
                     "80_real",
                     "86_real",
                     "90_real"
+                ]
+            }
+        },
+        "xpu": {
+            "intel": {
+                "device_ip": [
+                    "12.55.8",
+                    "12.60.7",
+                    "12.71.4",
+                    "12.74.4",
+                    "20.1.0",
+                    "20.4.4"
                 ]
             }
         }


### PR DESCRIPTION
This PR updates torch-2.8 configuration as that's what we can test with at the moment though pytorch 2.8 is already done. Likely we will need to prepare another PR for upcoming torch-2.9 and that has a chance to show up in actual release.

Tried with:
```
wget https://download.pytorch.org/whl/xpu/torch-2.8.0%2Bxpu-cp312-cp312-linux_x86_64.whl
wget https://download.pytorch.org/whl/xpu/torchvision-0.23.0%2Bxpu-cp312-cp312-manylinux_2_28_x86_64.whl

variant_repack build -i $(ls *xpu*.whl) -o ./torch/ \
  --pyproject-toml ./torch_pyproject.toml \
  --variant-config-toml ./torch_variant_config.toml \
  --variant-config-name intel \
  --metadata-config-name torch

variant_repack build -i $(ls torchvision-*xpu*.whl) -o ./torchvision/ \
  --pyproject-toml $CONFIG/torch_pyproject.toml \
  --variant-config-toml $CONFIG/torch_variant_config.toml \
  --variant-config-name intel --metadata-config-name torchvision
```

Intel variant provider can be found at https://github.com/wheelnext/intel-variant-provider. Dependencies can be taken unchanged from https://download.pytorch.org/whl/xpu.

CC: @atalman, @chuanqi129 