### PR TITLE
configs: torch-2.9 xpu configs

### DIFF
--- a/configs/torch-2.8/torch_variant_config.toml
+++ b/configs/torch-2.8/torch_variant_config.toml
@@ -76,7 +76,7 @@ deps_add_list    = ["torch==2.8.0"]
 
 [variant_configs]
 [variant_configs.cu126]
-variant_label = "cu126"  # [a-z0-9_]{1,8}
+variant_label = "cu126"  # [0-9a-z._]{1,16}
 properties = [
   { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.0" },
   { namespace = "nvidia", feature = "sm_arch", value = "50_real" },
@@ -89,7 +89,7 @@ properties = [
 ]
 
 [variant_configs.cu128]
-variant_label = "cu128"  # [a-z0-9_]{1,8}
+variant_label = "cu128"  # [0-9a-z._]{1,16}
 properties = [
   { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.8" },
   { namespace = "nvidia", feature = "sm_arch", value = "70_real" },
@@ -102,7 +102,7 @@ properties = [
 ]
 
 [variant_configs.cu129]
-variant_label = "cu129"  # [a-z0-9_]{1,8}
+variant_label = "cu129"  # [0-9a-z._]{1,16}
 properties = [
   { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.9" },
   { namespace = "nvidia", feature = "sm_arch", value = "70_real" },

--- a/configs/torch-2.9/torch-2.9.0-variants.json
+++ b/configs/torch-2.9/torch-2.9.0-variants.json
@@ -11,11 +11,11 @@
             "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
             "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
             "requires": [
-                "nvidia-variant-provider>=0.0.1,<1.0.0"
+                "nvidia-variant-provider>=0.0.2,<1.0.0"
             ]
         },
         "intel": {
-            "enable-if": "platform_system == 'Linux'",
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
             "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
             "requires": [
                 "intel-variant-provider>=0.0.2,<1.0.0"
@@ -23,7 +23,7 @@
         }
     },
     "variants": {
-        "00000000": {},
+        "null": {},
         "cu126": {
             "nvidia": {
                 "cuda_version_lower_bound": [
@@ -43,33 +43,32 @@
         "cu128": {
             "nvidia": {
                 "cuda_version_lower_bound": [
-                    "12.8"
+                    "12.0"
                 ],
                 "sm_arch": [
-                    "100_real",
-                    "120_real",
                     "70_real",
                     "75_real",
                     "80_real",
                     "86_real",
-                    "90_real"
+                    "90_real",
+                    "100_real",
+                    "120_real"
                 ]
             }
         },
-        "cu129": {
+        "cu13": {
             "nvidia": {
                 "cuda_version_lower_bound": [
-                    "12.9"
+                    "13.0"
                 ],
                 "sm_arch": [
-                    "100_real",
-                    "120_real",
-                    "120_virtual",
-                    "70_real",
                     "75_real",
                     "80_real",
                     "86_real",
-                    "90_real"
+                    "90_real",
+                    "100_real",
+                    "120_real",
+                    "120_virtual"
                 ]
             }
         },

--- a/configs/torch-2.9/torch-2.9.0-variants.json
+++ b/configs/torch-2.9/torch-2.9.0-variants.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "https://variants-schema.wheelnext.dev/v0.0.2.json",
+    "default-priorities": {
+        "namespace": [
+            "nvidia",
+            "intel"
+        ]
+    },
+    "providers": {
+        "nvidia": {
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
+            "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
+            "requires": [
+                "nvidia-variant-provider>=0.0.1,<1.0.0"
+            ]
+        },
+        "intel": {
+            "enable-if": "platform_system == 'Linux'",
+            "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
+            "requires": [
+                "intel-variant-provider>=0.0.2,<1.0.0"
+            ]
+        }
+    },
+    "variants": {
+        "00000000": {},
+        "cu126": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.0"
+                ],
+                "sm_arch": [
+                    "50_real",
+                    "60_real",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            }
+        },
+        "cu128": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.8"
+                ],
+                "sm_arch": [
+                    "100_real",
+                    "120_real",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            }
+        },
+        "cu129": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.9"
+                ],
+                "sm_arch": [
+                    "100_real",
+                    "120_real",
+                    "120_virtual",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            }
+        },
+        "xpu": {
+            "intel": {
+                "device_ip": [
+                    "12.55.8",
+                    "12.60.7",
+                    "12.71.4",
+                    "12.74.4",
+                    "20.1.0",
+                    "20.4.4"
+                ]
+            }
+        }
+    }
+}

--- a/configs/torch-2.9/torch_pyproject.toml
+++ b/configs/torch-2.9/torch_pyproject.toml
@@ -1,0 +1,13 @@
+# https://github.com/pytorch/pytorch/blob/b46ca66793573f00f5bb7f8664ae72b4a5f38a2a/pyproject.toml
+[variant.default-priorities]
+namespace = ["nvidia", "intel"]
+
+[variant.providers.nvidia]
+requires = ["nvidia-variant-provider>=0.0.1,<1.0.0"]
+plugin-api = "nvidia_variant_provider.plugin:NvidiaVariantPlugin"
+enable-if = "platform_system == 'Linux' or platform_system == 'Windows'"
+
+[variant.providers.intel]
+requires = ["intel-variant-provider"]
+enable-if = "platform_system == 'Linux'"
+plugin-api = "intel_variant_provider.plugin:IntelVariantPlugin"

--- a/configs/torch-2.9/torch_pyproject.toml
+++ b/configs/torch-2.9/torch_pyproject.toml
@@ -3,11 +3,11 @@
 namespace = ["nvidia", "intel"]
 
 [variant.providers.nvidia]
-requires = ["nvidia-variant-provider>=0.0.1,<1.0.0"]
+requires = ["nvidia-variant-provider>=0.0.2,<1.0.0"]
 plugin-api = "nvidia_variant_provider.plugin:NvidiaVariantPlugin"
 enable-if = "platform_system == 'Linux' or platform_system == 'Windows'"
 
 [variant.providers.intel]
-requires = ["intel-variant-provider"]
-enable-if = "platform_system == 'Linux'"
+requires = ["intel-variant-provider>=0.0.2,<1.0.0"]
+enable-if = "platform_system == 'Linux' or platform_system == 'Windows'"
 plugin-api = "intel_variant_provider.plugin:IntelVariantPlugin"

--- a/configs/torch-2.9/torch_variant_config.toml
+++ b/configs/torch-2.9/torch_variant_config.toml
@@ -1,0 +1,73 @@
+[metadata_configs]
+[metadata_configs.torch]
+normalize_package_name = false
+normalize_version = true
+deps_remove_list = [
+  # XPU
+  'dpcpp-cpp-rt',
+  'impi-rt',
+  'intel-cmplr-lib-rt',
+  'intel-cmplr-lib-ur',
+  'intel-cmplr-lic-rt',
+  'intel-opencl-rt',
+  'intel-openmp',
+  'intel-pti',
+  'intel-sycl-rt',
+  'mkl',
+  'oneccl-devel',
+  'oneccl',
+  'onemkl-sycl-blas',
+  'onemkl-sycl-dft',
+  'onemkl-sycl-lapack',
+  'onemkl-sycl-rng',
+  'onemkl-sycl-sparse',
+  'pytorch-triton-xpu',
+  'tbb',
+  'tcmlib',
+  'umf',
+]
+deps_add_list    = [
+    # XPU
+    'dpcpp-cpp-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'impi-rt==2021.16.1; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
+    'intel-cmplr-lib-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-cmplr-lib-ur==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-cmplr-lic-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-opencl-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-openmp==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-pti==0.13.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'intel-sycl-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
+    'mkl==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'oneccl-devel==2021.16.1; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
+    'oneccl==2021.16.1; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
+    'onemkl-sycl-blas==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-dft==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-lapack==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-rng==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'onemkl-sycl-sparse==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'pytorch-triton-xpu==3.5.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'tbb==2022.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'tcmlib==1.4.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    'umf==0.11.0; platform_system == "Linux" and "intel" in variant_namespaces',
+]
+
+[metadata_configs.torchvision]
+normalize_package_name = false
+normalize_version = true
+deps_remove_list = ["torch"]
+deps_add_list    = ["torch==2.9.0"]
+
+[variant_configs.intel]
+variant_label = "xpu"  # [a-z0-9_]{1,8}
+properties = [
+  { namespace = "intel", feature = "device_ip", value = "20.4.4" },   # lnl-m
+  { namespace = "intel", feature = "device_ip", value = "20.1.0" },   # bmg
+  { namespace = "intel", feature = "device_ip", value = "12.74.4" },  # arl-h
+  { namespace = "intel", feature = "device_ip", value = "12.71.4" },  # mtl-h
+  { namespace = "intel", feature = "device_ip", value = "12.60.7" },  # pvc
+  { namespace = "intel", feature = "device_ip", value = "12.55.8" },  # dg2
+]
+
+[variant_configs.cpu]
+# variant_label = None  # FORBIDDEN - No Alias -> NULL VARIANT: `00000000`
+properties = []

--- a/configs/torch-2.9/torch_variant_config.toml
+++ b/configs/torch-2.9/torch_variant_config.toml
@@ -27,28 +27,78 @@ deps_remove_list = [
   'umf',
 ]
 deps_add_list    = [
+    # Common to CUDA 12 builds
+    "triton==3.4.0; platform_system == 'Linux' and 'nvidia' in variant_namespaces",
+    "nvidia-cudnn==9.10.2.21; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
+    "nvidia-cusparselt==0.7.1; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
+    "nvidia-nccl==2.27.5; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
+    "nvidia-nvshmem==3.3.20; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
+
+    # CUDA 12.6
+    "nvidia-cublas==12.6.4.1; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cuda-cupti==12.6.80; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cuda-nvrtc==12.6.77; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cuda-runtime==12.6.77; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cufft==11.3.0.4; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cufile==1.11.1.6; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-curand==10.3.7.77; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cusolver==11.7.1.2; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-cusparse==12.5.4.2; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-nvjitlink==12.6.85; platform_system == 'Linux' and variant_label == 'cu126'",
+    "nvidia-nvtx==12.6.77; platform_system == 'Linux' and variant_label == 'cu126'",
+
+    # CUDA 12.8
+    "nvidia-cublas==12.8.4.1; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cuda-cupti==12.8.90; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cuda-nvrtc==12.8.93; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cuda-runtime==12.8.90; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cufft==11.3.3.83; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cufile==1.13.1.3; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-curand==10.3.9.90; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cusolver==11.7.3.90; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-cusparse==12.5.8.93; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-nvjitlink==12.8.93; platform_system == 'Linux' and variant_label == 'cu128'",
+    "nvidia-nvtx==12.8.90; platform_system == 'Linux' and variant_label == 'cu128'",
+
+    # CUDA 13
+    "nvidia-cublas==13.0.0.19; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cuda-cupti==13.0.48; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cuda-nvrtc==13.0.48; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cuda-runtime==13.0.48; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cudnn==9.13.0.50; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cufft==12.0.0.15; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cufile==1.15.0.42; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-curand==10.4.0.35; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cusolver==12.0.3.29; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cusparse==12.6.2.49; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-cusparselt==0.8.0; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-nccl==2.27.7; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-nvjitlink==13.0.39; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-nvshmem==3.3.24; platform_system == 'Linux' and variant_label == 'cu13'",
+    "nvidia-nvtx==13.0.39; platform_system == 'Linux' and variant_label == 'cu13'",
+
     # XPU
-    'dpcpp-cpp-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'impi-rt==2021.16.1; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
-    'intel-cmplr-lib-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'intel-cmplr-lib-ur==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'intel-cmplr-lic-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'intel-opencl-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'intel-openmp==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'intel-pti==0.13.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'intel-sycl-rt==2025.2.1; platform_system == "Linux" and "intel" in variant_namespaces',
-    'mkl==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'oneccl-devel==2021.16.1; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
-    'oneccl==2021.16.1; platform_system == "Linux" and platform_machine == "x86_64" and "intel" in variant_namespaces',
-    'onemkl-sycl-blas==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'onemkl-sycl-dft==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'onemkl-sycl-lapack==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'onemkl-sycl-rng==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'onemkl-sycl-sparse==2025.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'pytorch-triton-xpu==3.5.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'tbb==2022.2.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'tcmlib==1.4.0; platform_system == "Linux" and "intel" in variant_namespaces',
-    'umf==0.11.0; platform_system == "Linux" and "intel" in variant_namespaces',
+    "dpcpp-cpp-rt==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "impi-rt==2021.16.1; platform_system == 'Linux' and platform_machine == 'x86_64' and 'intel' in variant_namespaces",
+    "intel-cmplr-lib-rt==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "intel-cmplr-lib-ur==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "intel-cmplr-lic-rt==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "intel-opencl-rt==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "intel-openmp==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "intel-pti==0.13.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "intel-sycl-rt==2025.2.1; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "mkl==2025.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "oneccl-devel==2021.16.1; platform_system == 'Linux' and platform_machine == 'x86_64' and 'intel' in variant_namespaces",
+    "oneccl==2021.16.1; platform_system == 'Linux' and platform_machine == 'x86_64' and 'intel' in variant_namespaces",
+    "onemkl-sycl-blas==2025.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "onemkl-sycl-dft==2025.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "onemkl-sycl-lapack==2025.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "onemkl-sycl-rng==2025.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "onemkl-sycl-sparse==2025.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "pytorch-triton-xpu==3.5.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "tbb==2022.2.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "tcmlib==1.4.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
+    "umf==0.11.0; platform_system == 'Linux' and 'intel' in variant_namespaces",
 ]
 
 [metadata_configs.torchvision]
@@ -57,8 +107,51 @@ normalize_version = true
 deps_remove_list = ["torch"]
 deps_add_list    = ["torch==2.9.0"]
 
+
+# PyT CUDA `sm_archs`: https://github.com/pytorch/pytorch/blob/v2.9.0-rc4/.ci/manywheel/build_cuda.sh
+
+[variant_configs]
+[variant_configs.cu126]
+variant_label = "cu126"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.0" },
+  { namespace = "nvidia", feature = "sm_arch", value = "50_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "60_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "70_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "75_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "80_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "86_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "90_real" },
+]
+
+[variant_configs.cu128]
+variant_label = "cu128"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.0" },
+  { namespace = "nvidia", feature = "sm_arch", value = "70_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "75_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "80_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "86_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "90_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "100_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "120_real" },
+]
+
+[variant_configs.cu13]
+variant_label = "cu13"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "13.0" },
+  { namespace = "nvidia", feature = "sm_arch", value = "75_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "80_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "86_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "90_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "100_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "120_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "120_virtual" },
+]
+
 [variant_configs.intel]
-variant_label = "xpu"  # [a-z0-9_]{1,8}
+variant_label = "xpu"  # [0-9a-z._]{1,16}
 properties = [
   { namespace = "intel", feature = "device_ip", value = "20.4.4" },   # lnl-m
   { namespace = "intel", feature = "device_ip", value = "20.1.0" },   # bmg
@@ -69,5 +162,5 @@ properties = [
 ]
 
 [variant_configs.cpu]
-# variant_label = None  # FORBIDDEN - No Alias -> NULL VARIANT: `00000000`
+# variant_label = None  # FORBIDDEN - No Alias -> NULL VARIANT: `null`
 properties = []

--- a/configs/torch-2.9/torchvision-0.24.0-variants.json
+++ b/configs/torch-2.9/torchvision-0.24.0-variants.json
@@ -11,11 +11,11 @@
             "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
             "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
             "requires": [
-                "nvidia-variant-provider>=0.0.1,<1.0.0"
+                "nvidia-variant-provider>=0.0.2,<1.0.0"
             ]
         },
         "intel": {
-            "enable-if": "platform_system == 'Linux'",
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
             "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
             "requires": [
                 "intel-variant-provider>=0.0.2,<1.0.0"
@@ -23,7 +23,7 @@
         }
     },
     "variants": {
-        "00000000": {},
+        "null": {},
         "cu126": {
             "nvidia": {
                 "cuda_version_lower_bound": [
@@ -43,33 +43,32 @@
         "cu128": {
             "nvidia": {
                 "cuda_version_lower_bound": [
-                    "12.8"
+                    "12.0"
                 ],
                 "sm_arch": [
-                    "100_real",
-                    "120_real",
                     "70_real",
                     "75_real",
                     "80_real",
                     "86_real",
-                    "90_real"
+                    "90_real",
+                    "100_real",
+                    "120_real"
                 ]
             }
         },
-        "cu129": {
+        "cu13": {
             "nvidia": {
                 "cuda_version_lower_bound": [
-                    "12.9"
+                    "13.0"
                 ],
                 "sm_arch": [
-                    "100_real",
-                    "120_real",
-                    "120_virtual",
-                    "70_real",
                     "75_real",
                     "80_real",
                     "86_real",
-                    "90_real"
+                    "90_real",
+                    "100_real",
+                    "120_real",
+                    "120_virtual"
                 ]
             }
         },

--- a/configs/torch-2.9/torchvision-0.24.0-variants.json
+++ b/configs/torch-2.9/torchvision-0.24.0-variants.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "https://variants-schema.wheelnext.dev/v0.0.2.json",
+    "default-priorities": {
+        "namespace": [
+            "nvidia",
+            "intel"
+        ]
+    },
+    "providers": {
+        "nvidia": {
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
+            "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
+            "requires": [
+                "nvidia-variant-provider>=0.0.1,<1.0.0"
+            ]
+        },
+        "intel": {
+            "enable-if": "platform_system == 'Linux'",
+            "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
+            "requires": [
+                "intel-variant-provider>=0.0.2,<1.0.0"
+            ]
+        }
+    },
+    "variants": {
+        "00000000": {},
+        "cu126": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.0"
+                ],
+                "sm_arch": [
+                    "50_real",
+                    "60_real",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            }
+        },
+        "cu128": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.8"
+                ],
+                "sm_arch": [
+                    "100_real",
+                    "120_real",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            }
+        },
+        "cu129": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.9"
+                ],
+                "sm_arch": [
+                    "100_real",
+                    "120_real",
+                    "120_virtual",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            }
+        },
+        "xpu": {
+            "intel": {
+                "device_ip": [
+                    "12.55.8",
+                    "12.60.7",
+                    "12.71.4",
+                    "12.74.4",
+                    "20.1.0",
+                    "20.4.4"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR starts cooking Pytorch 2.9 variant configs. At the moment:
1. Added XPU dependencies respective to 2.9 RC (https://download.pytorch.org/whl/test/xpu)
2. Added Nvidia configuration (thank you, @DEKHTIARJonathan)

This PR requires these versions of plugins:
* https://github.com/wheelnext/intel-variant-provider/releases/tag/v0.0.2-rc1 (or later of v0.0.2 series)
* https://github.com/wheelnext/nvidia-variant-provider/releases/tag/v0.0.2

CC: @atalman @DEKHTIARJonathan 