### PR TITLE
Rename rocm configs rocm6_X_all_gfx_archs -> rocm6X

### DIFF
--- a/configs/torch-2.9/torch_variant_config.toml
+++ b/configs/torch-2.9/torch_variant_config.toml
@@ -210,7 +210,7 @@ properties = [
   { namespace = "intel", feature = "device_ip", value = "12.55.8" },  # dg2
 ]
 
-[variant_configs.rocm6_3_all_gfx_archs]
+[variant_configs.rocm63]
 variant_label = "rocm6.3"
 properties = [
     { namespace = "amd", feature = "rocm_version", value = "6.3" },
@@ -227,7 +227,7 @@ properties = [
     { namespace = "amd", feature = "gfx_arch", value = "gfx1201" },
 ]
 
-[variant_configs.rocm6_4_all_gfx_archs]
+[variant_configs.rocm64]
 variant_label = "rocm6.4"
 properties = [
     { namespace = "amd", feature = "rocm_version", value = "6.4" },


### PR DESCRIPTION
This rename  makes it easier to produce wheels
By doing something like:
```
ARCH_NO_DOT="${ARCH//./}"
variant_repack build -i "${orig_pkg}" -o /home/ec2-user/github/variant-repack/out_files --pyproject-toml /home/ec2-user/github/variant-repack/configs/torch-2.9/torch_pyproject.toml --variant-config-toml /home/ec2-user/github/variant-repack/configs/torch-2.9/torch_variant_config.toml --variant-config-name "${ARCH_NO_DOT}" --metadata-config-name "${PACKAGE_NAME}"
```