### PR TITLE
[torch 2.10] `uv` total resolution fix

### DIFF
--- a/configs/torch-2.10/torch_variant_config.toml
+++ b/configs/torch-2.10/torch_variant_config.toml
@@ -74,11 +74,11 @@ deps_add_list    = [
     "triton==3.6.0; platform_system == 'Linux' and 'nvidia' in variant_namespaces",
 
     # Common to CUDA 12 builds
-    "cuda-bindings==12.9.4; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
-    "nvidia-cudnn==9.10.2.21; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
-    "nvidia-cusparselt==0.7.1; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
-    "nvidia-nccl==2.27.5; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
-    "nvidia-nvshmem==3.4.5; platform_system == 'Linux' and 'nvidia :: cuda_version_lower_bound :: 12.0' in variant_properties",
+    "cuda-bindings==12.9.4; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-cudnn==9.10.2.21; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-cusparselt==0.7.1; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-nccl==2.27.5; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-nvshmem==3.4.5; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
 
     # CUDA 12.6
     "nvidia-cublas==12.6.4.1; platform_system == 'Linux' and variant_label == 'cuda12.6'",


### PR DESCRIPTION
Updated CUDA dependencies to be conditional on variant labels for versions 12.6 and 12.8.