### PR TITLE
[Pytorch 2.11] Variant configuration

### DIFF
--- a/configs/torch-2.11/torch-2.11.0-variants.json
+++ b/configs/torch-2.11/torch-2.11.0-variants.json
@@ -1,0 +1,173 @@
+{
+    "$schema": "https://variants-schema.wheelnext.dev/v0.0.3.json",
+    "default-priorities": {
+        "namespace": [
+            "nvidia",
+            "intel",
+            "amd",
+            "priority"
+        ]
+    },
+    "providers": {
+        "nvidia": {
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
+            "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
+            "requires": [
+                "nvidia-variant-provider>=0.0.2,<1.0.0"
+            ]
+        },
+        "intel": {
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
+            "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
+            "requires": [
+                "intel-variant-provider>=0.0.3,<1.0.0"
+            ]
+        },
+        "amd": {
+            "enable-if": "platform_system == 'Linux'",
+            "plugin-api": "amd_variant_provider.plugin:AMDVariantPlugin",
+            "requires": [
+                "amd-variant-provider>=0.0.2,<1.0.0"
+            ]
+        },
+        "priority": {
+            "install-time": false,
+            "requires": []
+        }
+    },
+    "static-properties": {
+        "priority": {
+            "order": [
+                "1",
+                "2",
+                "3"
+            ]
+        }
+    },
+    "variants": {
+        "null": {},
+        "cuda12.6": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.0"
+                ],
+                "sm_arch": [
+                    "50_real",
+                    "60_real",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            },
+            "priority": {
+                "order": [
+                    "3"
+                ]
+            }
+        },
+        "cuda12.8": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.0"
+                ],
+                "sm_arch": [
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real",
+                    "100_real",
+                    "120_real"
+                ]
+            },
+            "priority": {
+                "order": [
+                    "2"
+                ]
+            }
+        },
+        "cuda13.0": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "13.0"
+                ],
+                "sm_arch": [
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real",
+                    "100_real",
+                    "120_real",
+                    "120_virtual"
+                ]
+            },
+            "priority": {
+                "order": [
+                    "1"
+                ]
+            }
+        },
+        "xpu": {
+            "intel": {
+                "device_ip": [
+                    "12.55.8",
+                    "12.60.7",
+                    "12.71.4",
+                    "12.74.4",
+                    "20.1.0",
+                    "20.4.4",
+                    "30.0.4",
+                    "30.1.0"
+                ]
+            }
+        },
+        "rocm7.0": {
+            "amd": {
+                "gfx_arch": [
+                    "gfx1030",
+                    "gfx1100",
+                    "gfx1101",
+                    "gfx1102",
+                    "gfx1150",
+                    "gfx1151",
+                    "gfx1200",
+                    "gfx1201",
+                    "gfx900",
+                    "gfx906",
+                    "gfx908",
+                    "gfx90a",
+                    "gfx942",
+                    "gfx950"
+                ],
+                "rocm_version": [
+                    "7.0"
+                ]
+            }
+        },
+        "rocm7.1": {
+            "amd": {
+                "gfx_arch": [
+                    "gfx1030",
+                    "gfx1100",
+                    "gfx1101",
+                    "gfx1102",
+                    "gfx1150",
+                    "gfx1151",
+                    "gfx1200",
+                    "gfx1201",
+                    "gfx900",
+                    "gfx906",
+                    "gfx908",
+                    "gfx90a",
+                    "gfx942",
+                    "gfx950"
+                ],
+                "rocm_version": [
+                    "7.1"
+                ]
+            }
+        }
+    }
+}

--- a/configs/torch-2.11/torch_pyproject.toml
+++ b/configs/torch-2.11/torch_pyproject.toml
@@ -1,0 +1,24 @@
+[variant.default-priorities]
+namespace = ["nvidia", "intel", "amd", "priority"]
+
+[variant.providers.nvidia]
+requires = ["nvidia-variant-provider>=0.0.2,<1.0.0"]
+plugin-api = "nvidia_variant_provider.plugin:NvidiaVariantPlugin"
+enable-if = "platform_system == 'Linux' or platform_system == 'Windows'"
+
+[variant.providers.intel]
+requires = ["intel-variant-provider>=0.0.3,<1.0.0"]
+plugin-api = "intel_variant_provider.plugin:IntelVariantPlugin"
+enable-if = "platform_system == 'Linux' or platform_system == 'Windows'"
+
+[variant.providers.amd]
+requires = ["amd-variant-provider>=0.0.2,<1.0.0"]
+plugin-api = "amd_variant_provider.plugin:AMDVariantPlugin"
+enable-if = "platform_system == 'Linux'"
+
+[variant.providers.priority]
+install-time = false
+requires = []
+
+[variant.static-properties.priority]
+order = ["1", "2", "3"]

--- a/configs/torch-2.11/torch_variant_config.toml
+++ b/configs/torch-2.11/torch_variant_config.toml
@@ -1,0 +1,264 @@
+[metadata_configs]
+[metadata_configs.torch]
+normalize_package_name = false
+normalize_version = true
+deps_remove_list = [
+  # ====== NVIDIA CUDA ====== #
+  # CUDA 12.x
+  "nvidia-cublas-cu12",
+  "nvidia-cuda-cupti-cu12",
+  "nvidia-cuda-nvrtc-cu12",
+  "nvidia-cuda-runtime-cu12",
+  "nvidia-cudnn-cu12",
+  "nvidia-cufft-cu12",
+  "nvidia-cufile-cu12",
+  "nvidia-curand-cu12",
+  "nvidia-cusolver-cu12",
+  "nvidia-cusparse-cu12",
+  "nvidia-cusparselt-cu12",
+  "nvidia-nccl-cu12",
+  "nvidia-nvjitlink-cu12",
+  "nvidia-nvshmem-cu12",
+  "nvidia-nvtx-cu12",
+  # CUDA 13.0
+  "nvidia-cublas",
+  "nvidia-cuda-cupti",
+  "nvidia-cuda-nvrtc",
+  "nvidia-cuda-runtime",
+  "nvidia-cudnn-cu13",
+  "nvidia-cufft",
+  "nvidia-cufile",
+  "nvidia-curand",
+  "nvidia-cusolver",
+  "nvidia-cusparse",
+  "nvidia-cusparselt",
+  "nvidia-nccl-cu13",
+  "nvidia-nvjitlink",
+  "nvidia-nvshmem",
+  "nvidia-nvtx",
+  # Common to all
+  "cuda-bindings",
+  "triton",
+
+  # ====== INTEL ====== #
+  # XPU
+  "dpcpp-cpp-rt",
+  "impi-rt",
+  "intel-cmplr-lib-rt",
+  "intel-cmplr-lib-ur",
+  "intel-cmplr-lic-rt",
+  "intel-opencl-rt",
+  "intel-openmp",
+  "intel-pti",
+  "intel-sycl-rt",
+  "mkl",
+  "oneccl-devel",
+  "oneccl",
+  "onemkl-license",
+  "onemkl-sycl-blas",
+  "onemkl-sycl-dft",
+  "onemkl-sycl-lapack",
+  "onemkl-sycl-rng",
+  "onemkl-sycl-sparse",
+  "triton-xpu",
+  "tbb",
+  "tcmlib",
+  "umf",
+
+  # ====== AMD ====== #
+  # ROCM
+  "triton-rocm",
+]
+deps_add_list    = [
+    # Common to all CUDA builds
+    "triton==3.6.0; platform_system == 'Linux' and 'nvidia' in variant_namespaces",
+
+    # Common to CUDA 12 builds
+    "cuda-bindings==12.9.4; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-cudnn==9.10.2.21; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-cusparselt==0.7.1; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-nccl==2.27.5; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+    "nvidia-nvshmem==3.4.5; platform_system == 'Linux' and  (variant_label == 'cuda12.6' or variant_label == 'cuda12.8')",
+
+    # CUDA 12.6
+    "nvidia-cublas==12.6.4.1; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cuda-cupti==12.6.80; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cuda-nvrtc==12.6.77; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cuda-runtime==12.6.77; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cufft==11.3.0.4; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cufile==1.11.1.6; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-curand==10.3.7.77; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cusolver==11.7.1.2; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-cusparse==12.5.4.2; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-nvjitlink==12.6.85; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+    "nvidia-nvtx==12.6.77; platform_system == 'Linux' and variant_label == 'cuda12.6'",
+
+    # CUDA 12.8
+    "nvidia-cublas==12.8.4.1; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cuda-cupti==12.8.90; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cuda-nvrtc==12.8.93; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cuda-runtime==12.8.90; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cufft==11.3.3.83; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cufile==1.13.1.3; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-curand==10.3.9.90; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cusolver==11.7.3.90; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-cusparse==12.5.8.93; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-nvjitlink==12.8.93; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+    "nvidia-nvtx==12.8.90; platform_system == 'Linux' and variant_label == 'cuda12.8'",
+
+    # CUDA 13
+    "nvidia-cublas==13.1.0.3; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cuda-runtime==13.0.96; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cudnn==9.15.1.9; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cufft==12.0.0.61; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cufile==1.15.1.6; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-curand==10.4.0.35; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-cusparselt==0.8.0; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-nccl==2.28.9; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-nvshmem==3.4.5; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+    "nvidia-nvtx==13.0.85; platform_system == 'Linux' and variant_label == 'cuda13.0'",
+
+    # XPU
+    # impi-rt, oneccl and oneccl-devel are tight to Linux as XCCL distributed backend
+    # which uses them is available only on Linux
+    "dpcpp-cpp-rt==2025.3.2; 'intel' in variant_namespaces",
+    "impi-rt==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' and 'intel' in variant_namespaces",
+    "intel-cmplr-lib-rt==2025.3.2; 'intel' in variant_namespaces",
+    "intel-cmplr-lib-ur==2025.3.2; 'intel' in variant_namespaces",
+    "intel-cmplr-lic-rt==2025.3.2; 'intel' in variant_namespaces",
+    "intel-opencl-rt==2025.3.2; 'intel' in variant_namespaces",
+    "intel-openmp==2025.3.2; 'intel' in variant_namespaces",
+    "intel-pti==0.16.0; 'intel' in variant_namespaces",
+    "intel-sycl-rt==2025.3.2; 'intel' in variant_namespaces",
+    "mkl==2025.3.1; 'intel' in variant_namespaces",
+    "oneccl-devel==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' and 'intel' in variant_namespaces",
+    "oneccl==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' and 'intel' in variant_namespaces",
+    "onemkl-license==2025.3.1; 'intel' in variant_namespaces",
+    "onemkl-sycl-blas==2025.3.1; 'intel' in variant_namespaces",
+    "onemkl-sycl-dft==2025.3.1; 'intel' in variant_namespaces",
+    "onemkl-sycl-lapack==2025.3.1; 'intel' in variant_namespaces",
+    "onemkl-sycl-rng==2025.3.1; 'intel' in variant_namespaces",
+    "onemkl-sycl-sparse==2025.3.1; 'intel' in variant_namespaces",
+    "triton-xpu==3.7.0; 'intel' in variant_namespaces",
+    "tbb==2022.3.1; 'intel' in variant_namespaces",
+    "tcmlib==1.4.1; 'intel' in variant_namespaces",
+    "umf==1.0.3; 'intel' in variant_namespaces",
+
+    # Common to all ROCm Variants
+    'triton-rocm==3.6.0; platform_system == "Linux" and platform_machine == "x86_64" and "amd" in variant_namespaces',
+]
+
+[metadata_configs.torchvision]
+normalize_package_name = false
+normalize_version = true
+deps_remove_list = ["torch"]
+deps_add_list    = ["torch==2.10.0"]
+
+
+# PyT CUDA `sm_archs`: https://github.com/pytorch/pytorch/tree/v2.10.0-rc7/.ci/manywheel/build_cuda.sh
+
+[variant_configs]
+[variant_configs.cu126]
+variant_label = "cuda12.6"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.0" },
+  { namespace = "nvidia", feature = "sm_arch", value = "50_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "60_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "70_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "75_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "80_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "86_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "90_real" },
+  { namespace = "property", feature = "order", value = "3" },
+]
+
+[variant_configs.cu128]
+variant_label = "cuda12.8"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "12.0" },
+  { namespace = "nvidia", feature = "sm_arch", value = "70_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "75_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "80_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "86_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "90_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "100_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "120_real" },
+  { namespace = "property", feature = "order", value = "2" },
+]
+
+[variant_configs.cu130]
+variant_label = "cuda13.0"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "nvidia", feature = "cuda_version_lower_bound", value = "13.0" },
+  { namespace = "nvidia", feature = "sm_arch", value = "75_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "80_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "86_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "90_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "100_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "110_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "120_real" },
+  { namespace = "nvidia", feature = "sm_arch", value = "120_virtual" },
+  { namespace = "property", feature = "order", value = "1" },
+]
+
+[variant_configs.xpu]
+variant_label = "xpu"  # [0-9a-z._]{1,16}
+properties = [
+  { namespace = "intel", feature = "device_ip", value = "20.4.4" },   # lnl-m
+  { namespace = "intel", feature = "device_ip", value = "20.1.0" },   # bmg
+  { namespace = "intel", feature = "device_ip", value = "12.74.4" },  # arl-h
+  { namespace = "intel", feature = "device_ip", value = "12.71.4" },  # mtl-h
+  { namespace = "intel", feature = "device_ip", value = "12.60.7" },  # pvc
+  { namespace = "intel", feature = "device_ip", value = "12.55.8" },  # dg2
+  { namespace = "intel", feature = "device_ip", value = "30.0.4" },   # ptl, ptl-h
+  { namespace = "intel", feature = "device_ip", value = "30.1.0" },   # ptl-u
+]
+
+[variant_configs.rocm70]
+variant_label = "rocm7.0"
+properties = [
+    { namespace = "amd", feature = "rocm_version", value = "7.0" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx900" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx906" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx908" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx90a" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx942" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx950" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1030" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1100" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1101" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1102" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1150" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1151" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1200" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1201" },
+]
+
+[variant_configs.rocm71]
+variant_label = "rocm7.1"
+properties = [
+    { namespace = "amd", feature = "rocm_version", value = "7.0" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx900" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx906" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx908" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx90a" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx942" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx950" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1030" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1100" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1101" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1102" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1150" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1151" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1200" },
+    { namespace = "amd", feature = "gfx_arch", value = "gfx1201" },
+]
+
+[variant_configs.cpu]
+# variant_label = None  # FORBIDDEN - No Alias -> NULL VARIANT: `null`
+properties = []

--- a/configs/torch-2.11/torchvision-0.26.0-variants.json
+++ b/configs/torch-2.11/torchvision-0.26.0-variants.json
@@ -1,0 +1,173 @@
+{
+    "$schema": "https://variants-schema.wheelnext.dev/v0.0.3.json",
+    "default-priorities": {
+        "namespace": [
+            "nvidia",
+            "intel",
+            "amd",
+            "priority"
+        ]
+    },
+    "providers": {
+        "nvidia": {
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
+            "plugin-api": "nvidia_variant_provider.plugin:NvidiaVariantPlugin",
+            "requires": [
+                "nvidia-variant-provider>=0.0.2,<1.0.0"
+            ]
+        },
+        "intel": {
+            "enable-if": "platform_system == 'Linux' or platform_system == 'Windows'",
+            "plugin-api": "intel_variant_provider.plugin:IntelVariantPlugin",
+            "requires": [
+                "intel-variant-provider>=0.0.3,<1.0.0"
+            ]
+        },
+        "amd": {
+            "enable-if": "platform_system == 'Linux'",
+            "plugin-api": "amd_variant_provider.plugin:AMDVariantPlugin",
+            "requires": [
+                "amd-variant-provider>=0.0.2,<1.0.0"
+            ]
+        },
+        "priority": {
+            "install-time": false,
+            "requires": []
+        }
+    },
+    "static-properties": {
+        "priority": {
+            "order": [
+                "1",
+                "2",
+                "3"
+            ]
+        }
+    },
+    "variants": {
+        "null": {},
+        "cuda12.6": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.0"
+                ],
+                "sm_arch": [
+                    "50_real",
+                    "60_real",
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real"
+                ]
+            },
+            "priority": {
+                "order": [
+                    "3"
+                ]
+            }
+        },
+        "cuda12.8": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "12.0"
+                ],
+                "sm_arch": [
+                    "70_real",
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real",
+                    "100_real",
+                    "120_real"
+                ]
+            },
+            "priority": {
+                "order": [
+                    "2"
+                ]
+            }
+        },
+        "cuda13.0": {
+            "nvidia": {
+                "cuda_version_lower_bound": [
+                    "13.0"
+                ],
+                "sm_arch": [
+                    "75_real",
+                    "80_real",
+                    "86_real",
+                    "90_real",
+                    "100_real",
+                    "120_real",
+                    "120_virtual"
+                ]
+            },
+            "priority": {
+                "order": [
+                    "1"
+                ]
+            }
+        },
+        "xpu": {
+            "intel": {
+                "device_ip": [
+                    "12.55.8",
+                    "12.60.7",
+                    "12.71.4",
+                    "12.74.4",
+                    "20.1.0",
+                    "20.4.4",
+                    "30.0.4",
+                    "30.1.0"
+                ]
+            }
+        },
+        "rocm7.0": {
+            "amd": {
+                "gfx_arch": [
+                    "gfx1030",
+                    "gfx1100",
+                    "gfx1101",
+                    "gfx1102",
+                    "gfx1150",
+                    "gfx1151",
+                    "gfx1200",
+                    "gfx1201",
+                    "gfx900",
+                    "gfx906",
+                    "gfx908",
+                    "gfx90a",
+                    "gfx942",
+                    "gfx950"
+                ],
+                "rocm_version": [
+                    "7.0"
+                ]
+            }
+        },
+        "rocm7.1": {
+            "amd": {
+                "gfx_arch": [
+                    "gfx1030",
+                    "gfx1100",
+                    "gfx1101",
+                    "gfx1102",
+                    "gfx1150",
+                    "gfx1151",
+                    "gfx1200",
+                    "gfx1201",
+                    "gfx900",
+                    "gfx906",
+                    "gfx908",
+                    "gfx90a",
+                    "gfx942",
+                    "gfx950"
+                ],
+                "rocm_version": [
+                    "7.1"
+                ]
+            }
+        }
+    }
+}

--- a/variant_repack/commands/build.py
+++ b/variant_repack/commands/build.py
@@ -22,7 +22,6 @@ from variantlib.constants import NULL_VARIANT_LABEL
 from variantlib.constants import VALIDATION_VARIANT_LABEL_REGEX
 from variantlib.constants import VALIDATION_WHEEL_NAME_REGEX
 from variantlib.constants import VARIANT_DIST_INFO_FILENAME
-from variantlib.constants import VARIANT_LABEL_LENGTH
 from variantlib.pyproject_toml import VariantPyProjectToml
 from wheel._commands.pack import pack as wheel_pack
 from wheel._commands.unpack import unpack as wheel_unpack
@@ -310,8 +309,8 @@ def make_variant(
 
     if not VALIDATION_VARIANT_LABEL_REGEX.fullmatch(variant_label):
         raise ValueError(
-            f"invalid variant label (must be up to {VARIANT_LABEL_LENGTH} alphanumeric "
-            f"characters): {variant_label!r}"
+            f"invalid variant label (must consist only of alphanumeric characters, "
+            f"underscores and dots): {variant_label!r}"
         )
 
     # ============================================== #


### PR DESCRIPTION
Changes vs. pytorch 2.10:
* Dropped `VARIANT_LABEL_LENGTH` due to change in variantlib
* Bumped XPU dependency versions to match pytorch 2.11

Requires: https://github.com/wheelnext/variantlib/pull/131